### PR TITLE
Use a favicon with administration screens.

### DIFF
--- a/includes/form/site.php
+++ b/includes/form/site.php
@@ -7,6 +7,8 @@
         <p><?php _e('Please upload .ico image.', 'wp-total-hacks'); ?></p>
         <input type="text" id="wfb_favicon" name="wfb_favicon" class="media" value="<?php $this->op('wfb_favicon'); ?>" />
         <a class="media-upload" href="JavaScript:void(0);" rel="wfb_favicon"><?php _e('Select File', 'wp-total-hacks'); ?></a>
+        <p><?php _e('In addition, use this favicon with administration screens.', 'wp-total-hacks'); ?></p>
+        <?php $this->sel('wfb_admin_favicon'); ?>
     </div>
 </div>
 

--- a/wp-total-hacks.php
+++ b/wp-total-hacks.php
@@ -19,6 +19,7 @@ class TotalHacks {
 private $option_params = array(
     'wfb_google_analytics' => 'text',
     'wfb_favicon' => 'url',
+    'wfb_admin_favicon' => 'bool',
     'wfb_apple_icon' => 'url',
     'wfb_hide_version' => 'bool',
     'wfb_google' => 'text',
@@ -245,6 +246,10 @@ public function wp_head()
 
 public function admin_head()
 {
+    if ($this->op('wfb_favicon') && $this->op('wfb_admin_favicon')) {
+        $link = '<link rel="Shortcut Icon" type="image/x-icon" href="%s" />'."\n";
+        printf($link, esc_url($this->op("wfb_favicon")));
+    }
     if (!$this->op("wfb_custom_logo")) {
         return;
     }


### PR DESCRIPTION
こんにちは。
便利に使わせていただいています。
#20 は、元は私が言ったことですかね。

管理画面でも favicon があったらうれしいな、と思うのは、
- 自分の管理画面をブラウザのブックマークに入れている場合、そこに favicon が表示されるとすぐに視認できる
- 複数のWPサイトを持っていて、ブラウザで同時に複数の管理画面を開いているときに、タブに favicon が出てくれると見分けがつきやすい

というような理由です。

「管理画面でも favicon を使う」かどうかのスイッチをつければ、これがなくてもいいと思っているこれまでのユーザーには影響しないので、
そのようなパッチを書いてみました。

どうかご検討ください。

git や github を使い始めたばかりでまだ要領を得ていません。もし失礼があったらお赦しください。
